### PR TITLE
:lipstick: Document all class members

### DIFF
--- a/lndocs/lamin_sphinx/__init__.py
+++ b/lndocs/lamin_sphinx/__init__.py
@@ -67,8 +67,6 @@ myst_enable_extensions = [
 ]
 myst_title_to_header = True  # allow frontmatter titles
 
-# Generate the API documentation
-autosummary_generate = True
 autodoc_member_order = "bysource"
 napoleon_google_docstring = True
 napoleon_include_init_with_doc = False
@@ -85,6 +83,11 @@ nitpicky = True  # report broken links
 
 bibtex_bibfiles = ["references.bib"]
 bibtex_default_style = "unsrt"
+
+
+nitpick_ignore = [
+    ("py:class", "pandas.core.frame.DataFrame"),
+]
 
 
 def setup(app: Sphinx):

--- a/lndocs/lamin_sphinx/_templates/autosummary/class.rst
+++ b/lndocs/lamin_sphinx/_templates/autosummary/class.rst
@@ -1,0 +1,31 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+      :toctree: .
+   {% for item in attributes %}
+      {{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :toctree: .
+   {% for item in methods %}
+      {% if '__init__' not in item %}
+         {{ name }}.{{ item }}
+      {% endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}


### PR DESCRIPTION
I went through the exact same rabbit hole of how to get rid of the crappy default configuration for class documentation as 6 years ago!

I fixed it, which makes the classes pretty & fixes the broken links. Methods and attributes are now documented!

Before | After
--- | ---
<img width="779" alt="image" src="https://user-images.githubusercontent.com/16916678/173133220-dca10b6a-93d3-4fdf-9e32-d70e1cb1966b.png"> | <img width="934" alt="image" src="https://user-images.githubusercontent.com/16916678/173134611-74fa96d6-3410-4611-bf69-b76e203e3335.png">

