### PR TITLE
🚸 Avoid flickering logo by using URL

### DIFF
--- a/lndocs/lamin_sphinx/__init__.py
+++ b/lndocs/lamin_sphinx/__init__.py
@@ -55,7 +55,9 @@ html_context = {
     "github_version": "main",
 }
 
-html_logo = "../lamin_sphinx/_static/img/logo.svg"
+html_logo = (
+    "https://raw.githubusercontent.com/laminlabs/lamin-profile/main/assets/logo.svg"
+)
 html_favicon = "../lamin_sphinx/_static/img/favicon.ico"
 html_static_path = ["../lamin_sphinx/_static"]
 

--- a/lndocs/lamin_sphinx/_templates/navbar-logo.html
+++ b/lndocs/lamin_sphinx/_templates/navbar-logo.html
@@ -1,28 +1,16 @@
 {% if logo %} {% if not theme_logo_link %}
 <a class="navbar-brand" href="{{ pathto(master_doc) }}">
-  <img
-    src="{{ pathto('_static/' + logo, 1) }}"
-    class="navbar__logo"
-    alt="logo"
-  />
+  <img src="{{ logo }}" class="navbar__logo" alt="logo" />
   <p class="navbar__title">{{ project }}</p>
 </a>
 {% elif theme_logo_link[:4] == 'http' %}
 <a class="navbar-brand" href="{{ theme_logo_link }}">
-  <img
-    src="{{ pathto('_static/' + logo, 1) }}"
-    class="navbar__logo"
-    alt="logo"
-  />
+  <img src="{{ logo }}" class="navbar__logo" alt="logo" />
   <p class="navbar__title">{{ project }}</p>
 </a>
 {% else %}
 <a class="navbar-brand" href="{{ pathto(theme_logo_link) }}">
-  <img
-    src="{{ pathto('_static/' + logo, 1) }}"
-    class="navbar__logo"
-    alt="logo"
-  />
+  <img src="{{ logo }}" class="navbar__logo" alt="logo" />
   <p class="navbar__title">{{ project }}</p>
 </a>
 {% endif %} {% else %}


### PR DESCRIPTION
On any subpage, the Lamin logo in the left-top page flickered when navigating.

It seems that the reload of the subdirectory took a finite time as there is a detour through the server redirect of the main page.

Now, we're loading the logo from an external URL and this fixes the issue.

The commits were actually already made on the main branch and the below commit merely summarizes them!