### PR TITLE
Add py:class binaryIO to nitpick ignore

### DIFF
--- a/lndocs/lamin_sphinx/_nitpick_ignore.py
+++ b/lndocs/lamin_sphinx/_nitpick_ignore.py
@@ -37,6 +37,7 @@ nitpick_ignore = [
     ("py:class", "unicode"),
     ("py:class", "typing.DictStrAny"),
     ("py:class", "typing.unicode"),
+    ("py:class", "typing.BinaryIO"),
     ("py:data", "typing.Optional"),
     ("py:data", "typing.Literal"),
     ("py:data", "typing.Union"),


### PR DESCRIPTION
Hopefully fixes https://github.com/laminlabs/bionty/issues/174

This was the idea, right @sunnyosun ?

Signed-off-by: zethson <lukas.heumos@posteo.net>