### PR TITLE
💄 Drop down headers non-bold

### DIFF
--- a/lndocs/lamin_sphinx/_static/custom.css
+++ b/lndocs/lamin_sphinx/_static/custom.css
@@ -410,6 +410,18 @@ nav.bd-links p.caption {
   max-width: 16rem;
 }
 
+/* --------- */
+/* Dropdowns */
+/* --------- */
+
+details.sd-dropdown {
+  box-shadow: none !important;
+}
+
+details.sd-dropdown summary.sd-card-header {
+  font-weight: 400;
+}
+
 /* ---- */
 /* Body */
 /* ---- */
@@ -483,10 +495,6 @@ div.admonition {
 }
 
 .form-control:focus {
-  box-shadow: none !important;
-}
-
-details.sd-dropdown {
   box-shadow: none !important;
 }
 


### PR DESCRIPTION
old:
<img width="824" alt="image" src="https://github.com/laminlabs/lndocs/assets/16916678/a36a11c0-4f7c-4bc8-af11-82a36ed9a72f">

new:
<img width="766" alt="image" src="https://github.com/laminlabs/lndocs/assets/16916678/17ba8393-ea44-4836-8815-775e62ebed38">
