### PR TITLE
💄 Less borders around code cells and drop downs

### DIFF
--- a/lndocs/lamin_sphinx/_static/custom.css
+++ b/lndocs/lamin_sphinx/_static/custom.css
@@ -116,6 +116,23 @@ h6 code {
   border: 0px;
 }
 
+pre {
+  border: unset;
+}
+
+div.cell div.cell_input,
+div.cell details.above-input > summary {
+  border: unset;
+  border-left-color: unset;
+  border-left-width: unset;
+}
+
+div.cell details.below-input > summary {
+  border: unset;
+  border-left-color: unset;
+  border-left-width: unset;
+}
+
 /* counteract the statement below */
 
 .highlight-default.notranslate {
@@ -454,6 +471,7 @@ details.sd-dropdown summary.sd-card-header {
 details.sd-dropdown summary.sd-card-header,
 details.sd-dropdown summary.sd-card-header + div.sd-summary-content {
   --pst-sd-dropdown-color: seagreen;
+  border-left: unset !important;
 }
 
 /* ---- */


### PR DESCRIPTION
before | after
--- | ---
<img width="837" alt="image" src="https://github.com/user-attachments/assets/ebc41d84-fc3a-47f7-896e-ea80119435d4"> | <img width="837" alt="image" src="https://github.com/user-attachments/assets/e1733f5a-7904-4325-83c9-260942c099d0">

