### PR TITLE
💄 Align top of 3 columns

### DIFF
--- a/lndocs/lamin_sphinx/_static/custom.css
+++ b/lndocs/lamin_sphinx/_static/custom.css
@@ -399,7 +399,7 @@ nav {
 
 .bd-sidebar-primary .sidebar-end-items__item,
 .bd-sidebar-primary .sidebar-start-items__item {
-  padding: unset;
+  padding-top: 4px;
 }
 
 /* caption for sidebar bav */


### PR DESCRIPTION
before | after
--- | ---
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/e4982de5-98ab-4f07-a9cd-189edde6edc1"> | <img width="1178" alt="image" src="https://github.com/user-attachments/assets/b02b5dce-8e7f-4ff4-abf1-d73c9eceb2fa">
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/6d52ccfa-1a1f-4efe-a051-2be57496e743"> | <img width="1138" alt="image" src="https://github.com/user-attachments/assets/cb8e9f4e-a16a-4ab8-a785-f09a81ba4cf8">
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/7d1403ed-1a8a-4ee6-812e-d2a9e73cf0fb"> | <img width="1143" alt="image" src="https://github.com/user-attachments/assets/f08b9e50-f5da-4d2c-94ad-16c2b0327885">

We have the additional problem that the buttons at the top are paragraphs, and paragraphs currently have margin-top 1.15rem. This is why it still looks somewhat misaligned with buttons above the heading. I don't want to change the paragraph properties in this without much more careful consideration though.


