### PR TITLE
✨ Show relationships for all registries

### DIFF
--- a/lndocs/lamin_sphinx/__init__.py
+++ b/lndocs/lamin_sphinx/__init__.py
@@ -562,19 +562,18 @@ def process_docstring(app, what, name, obj, options, lines):
             for field in registry_info.get_simple_fields():
                 attributes_to_exclude.add(field.name)
                 field_lines.append(f".. autoattribute:: {field.name}\n")
-            if obj in {Artifact, Collection, Transform}:
-                (
-                    core_relations,
-                    _,
-                ) = registry_info.get_relational_fields()
-                if core_relations:  # in fact always true
-                    field_lines.append("")
-                    field_lines.append("Relational fields")
-                    field_lines.append("-----------------")
-                    field_lines.append("")
-                for field in core_relations:
-                    field_lines.append(f".. autoattribute:: {field.name}\n")
-            # external relations don't yet work
+            (
+                core_relations,
+                _,
+            ) = registry_info.get_relational_fields()
+            if core_relations:  # in fact always true
+                field_lines.append("")
+                field_lines.append("Relational fields")
+                field_lines.append("-----------------")
+                field_lines.append("")
+            for field in core_relations:
+                field_lines.append(f".. autoattribute:: {field.name}\n")
+            # external relations don't work & maybe we don't need them in the docs
             # for module_name, module_relations in external_relations.items():
             #     field_lines.append("")
             #     field_lines.append(f"{module_name.capitalize()} fields")


### PR DESCRIPTION
With the below change, the docs are now building:

- https://github.com/laminlabs/lnschema-core/pull/429

For some reason, documenting `ManyToOneRel` raises many errors of the below form.

<details><summary>Details</summary>
<p>

```
WARNING: autodoc: failed to import attribute 'FeatureValue.artifact' from module 'lamindb.core'; the following exception was raised:
Traceback (most recent call last):
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/sphinx/util/inspect.py", line 374, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: type object 'FeatureValue' has no attribute 'artifact'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 209, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 329, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 2845, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/Users/falexwolf/miniconda3/envs/py310/lib/python3.10/site-packages/sphinx/util/inspect.py", line 390, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: artifact
```

</p>
</details> 

