### PR TITLE
💄 Pretty code tabs

### DIFF
--- a/lndocs/lamin_sphinx/_static/custom.css
+++ b/lndocs/lamin_sphinx/_static/custom.css
@@ -166,6 +166,27 @@ span.highlighted {
   background-color: unset;
 }
 
+/* ---- */
+/* Tabs */
+/* ---- */
+
+/* via the myst tabs feature, **not** sphinx-tabs: https://github.com/laminlabs/lamin-docs/pull/175 */
+
+.sd-tab-set {
+  margin-top: 0em !important;
+}
+
+.sd-tab-content {
+  box-shadow: 0 -0.0625rem var(--sd-color-tabs-underline), 0 0 !important;
+  padding-bottom: 0.75rem !important;
+}
+
+.sd-tab-set > label {
+  font-size: 1rem !important;
+  font-weight: 400 !important;
+  padding-top: 0 !important;
+}
+
 /* ------ */
 /* Tables */
 /* ------ */


### PR DESCRIPTION
Before | After
--- | ---
<img width="509" alt="image" src="https://github.com/user-attachments/assets/e1dbd20e-ee12-4e76-afc5-ed65c629aeb2"> | <img width="494" alt="image" src="https://github.com/user-attachments/assets/3f3898d1-b541-4c47-8a8e-a8f8c63641aa">

For context, see:

- https://github.com/laminlabs/lamin-docs/pull/175