### PR TITLE
💄 Hide `Schema.validated_by` and `.validated_schemas` from docs

### DIFF
--- a/lndocs/lamin_sphinx/__init__.py
+++ b/lndocs/lamin_sphinx/__init__.py
@@ -547,6 +547,7 @@ def process_docstring(app, what, name, obj, options, lines):
             Record,
             RegistryInfo,
             Run,
+            Schema,
             Transform,
             User,
         )
@@ -580,6 +581,11 @@ def process_docstring(app, what, name, obj, options, lines):
                 field_lines.append("-----------------")
                 field_lines.append("")
             for field in core_relations:
+                if obj is Schema and field.name in {
+                    "validated_by",
+                    "validated_schemas",
+                }:
+                    continue
                 field_lines.append(f".. autoattribute:: {field.name}\n")
             # external relations don't work & maybe we don't need them in the docs
             # for module_name, module_relations in external_relations.items():


### PR DESCRIPTION
For clean docs in the context of:

- https://github.com/laminlabs/lamindb/pull/2453