### PR TITLE
💄 Fix white space injection in TOC for code snippets

### DIFF
--- a/lndocs/lamin_sphinx/__init__.py
+++ b/lndocs/lamin_sphinx/__init__.py
@@ -494,6 +494,11 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
                 a = li.find("a")
                 a["class"] = a.get("class", []) + ["nav-link"]
 
+        # Normalize inline-code text in TOC labels so formatting whitespace
+        # does not become visible as extra space inside code pills.
+        for span in soup.select("code > span.pre"):
+            span.string = span.get_text().strip()
+
         # If we only have one h1 header, assume it's a title
         h1_headers = soup.select(".toc-h1")
         if len(h1_headers) == 1:
@@ -502,10 +507,13 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
             if not title.select(".toc-h2"):
                 out = ""
             else:
-                out = title.find("ul").prettify()
+                # Use compact HTML to avoid prettify()-inserted whitespace
+                # showing up inside inline code spans in the sidebar TOC.
+                out = str(title.find("ul"))
         # Else treat the h1 headers as sections
         else:
-            out = soup.prettify()
+            # Keep whitespace stable in TOC labels (especially inline code).
+            out = str(soup)
 
         # Return the toctree object
         if kind == "html":


### PR DESCRIPTION
Before | After
--- | ---
<img width="245" height="431" alt="image" src="https://github.com/user-attachments/assets/65752c57-1d5c-434f-9b0d-e8f89ad30dc9" /> | <img width="295" height="436" alt="image" src="https://github.com/user-attachments/assets/d8e2215f-b1a6-44e4-b0f2-005639d0d093" />